### PR TITLE
Piranh 8.4.0, PA0003, PA0004, PA0005

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 8.2.0.{build}
+version: 8.4.0.{build}
 branches:
   only:
   - master

--- a/docs/AnalyzerReleases.Shipped.md
+++ b/docs/AnalyzerReleases.Shipped.md
@@ -5,3 +5,6 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 PA0001 | Usage | Info | NonSingleFieldRegionAnalyzer, [Documentation](PA0001/README.md)
 PA0002 | Usage | Error | InvalidSingleFieldComplexRegionAnalyzer, [Documentation](PA0002/README.md)
+PA0003 | Usage | Error | PostTypeAttributeOnlyForClassesInheritingPostAnalyzer, [Documentation](PA0003/README.md)
+PA0004 | Usage | Error | PageTypeAttributeOnlyForClassesInheritingPageAnalyzer, [Documentation](PA0004/README.md)
+PA0005 | Usage | Error | SiteTypeAttributeOnlyForClassesInheritingSiteContentAnalyzer, [Documentation](PA0005/README.md)

--- a/docs/AnalyzerReleases.Unshipped.md
+++ b/docs/AnalyzerReleases.Unshipped.md
@@ -3,3 +3,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 PA0003 | Usage | Error | PostTypeAttributeOnlyForClassesInheritingPostAnalyzer, [Documentation](PA0003/README.md)
 PA0004 | Usage | Error | PageTypeAttributeOnlyForClassesInheritingPageAnalyzer, [Documentation](PA0004/README.md)
+PA0005 | Usage | Error | SiteTypeAttributeOnlyForClassesInheritingSiteContentAnalyzer, [Documentation](PA0005/README.md)

--- a/docs/AnalyzerReleases.Unshipped.md
+++ b/docs/AnalyzerReleases.Unshipped.md
@@ -1,3 +1,4 @@
 ﻿### New Rules
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+PA0003 | Usage | Error | PostTypeAttributeOnlyForClassesInheritingPostAnalyzer, [Documentation](PA0003/README.md)

--- a/docs/AnalyzerReleases.Unshipped.md
+++ b/docs/AnalyzerReleases.Unshipped.md
@@ -2,3 +2,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 PA0003 | Usage | Error | PostTypeAttributeOnlyForClassesInheritingPostAnalyzer, [Documentation](PA0003/README.md)
+PA0004 | Usage | Error | PageTypeAttributeOnlyForClassesInheritingPageAnalyzer, [Documentation](PA0004/README.md)

--- a/docs/AnalyzerReleases.Unshipped.md
+++ b/docs/AnalyzerReleases.Unshipped.md
@@ -1,6 +1,3 @@
 ﻿### New Rules
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-PA0003 | Usage | Error | PostTypeAttributeOnlyForClassesInheritingPostAnalyzer, [Documentation](PA0003/README.md)
-PA0004 | Usage | Error | PageTypeAttributeOnlyForClassesInheritingPageAnalyzer, [Documentation](PA0004/README.md)
-PA0005 | Usage | Error | SiteTypeAttributeOnlyForClassesInheritingSiteContentAnalyzer, [Documentation](PA0005/README.md)

--- a/docs/PA0003/README.md
+++ b/docs/PA0003/README.md
@@ -1,0 +1,10 @@
+# PA0003 - Classes marked with the PostTypeAttribute should inherit Post
+
+The analyzer will check classes marked with the `Piranha.AttributeBuilder.PostTypeAttribute` and mark the class as violating if it does not inherit `Piranha.Models.Post<T>`.
+
+| Severity | Category |
+|----------|----------|
+| Error    | Usage    |
+
+## Available code fixes
+None currently.

--- a/docs/PA0004/README.md
+++ b/docs/PA0004/README.md
@@ -1,0 +1,10 @@
+# PA0004 - Classes marked with the PageTypeAttribute should inherit Page
+
+The analyzer will check classes marked with the `Piranha.AttributeBuilder.PageTypeAttribute` and mark the class as violating if it does not inherit `Piranha.Models.Page<T>`.
+
+| Severity | Category |
+|----------|----------|
+| Error    | Usage    |
+
+## Available code fixes
+None currently.

--- a/docs/PA0005/README.md
+++ b/docs/PA0005/README.md
@@ -1,0 +1,10 @@
+# PA0005 - Classes marked with the SiteTypeAttribute should inherit SiteContent
+
+The analyzer will check classes marked with the `Piranha.AttributeBuilder.SiteTypeAttribute` and mark the class as violating if it does not inherit `Piranha.Models.SiteContent<T>`.
+
+| Severity | Category |
+|----------|----------|
+| Error    | Usage    |
+
+## Available code fixes
+None currently.

--- a/src/Piranha.Analyzers/Constants.cs
+++ b/src/Piranha.Analyzers/Constants.cs
@@ -19,6 +19,8 @@ namespace Piranha.Analyzers
 
         internal static class Types
         {
+            internal const string PiranhaAttributeBuilderPostTypeAttribute = "Piranha.AttributeBuilder.PostTypeAttribute";
+
             internal const string PiranhaExtendFieldAttribute = "Piranha.Extend.FieldAttribute";
             internal const string PiranhaExtendRegionAttribute = "Piranha.Extend.RegionAttribute";
 
@@ -33,6 +35,8 @@ namespace Piranha.Analyzers
             internal const string PiranhaExtendFieldsPostField = "Piranha.Extend.Fields.PostField";
             internal const string PiranhaExtendFieldsStringField = "Piranha.Extend.Fields.StringField";
             internal const string PiranhaExtendFieldsVideoField = "Piranha.Extend.Fields.VideoField";
+
+            internal const string PiranhaModelsPost = "Piranha.Models.Post";
         }
     }
 }

--- a/src/Piranha.Analyzers/Constants.cs
+++ b/src/Piranha.Analyzers/Constants.cs
@@ -19,6 +19,7 @@ namespace Piranha.Analyzers
 
         internal static class Types
         {
+            internal const string PiranhaAttributeBuilderPageTypeAttribute = "Piranha.AttributeBuilder.PageTypeAttribute";
             internal const string PiranhaAttributeBuilderPostTypeAttribute = "Piranha.AttributeBuilder.PostTypeAttribute";
 
             internal const string PiranhaExtendFieldAttribute = "Piranha.Extend.FieldAttribute";
@@ -36,6 +37,7 @@ namespace Piranha.Analyzers
             internal const string PiranhaExtendFieldsStringField = "Piranha.Extend.Fields.StringField";
             internal const string PiranhaExtendFieldsVideoField = "Piranha.Extend.Fields.VideoField";
 
+            internal const string PiranhaModelsPage = "Piranha.Models.Page";
             internal const string PiranhaModelsPost = "Piranha.Models.Post";
         }
     }

--- a/src/Piranha.Analyzers/Constants.cs
+++ b/src/Piranha.Analyzers/Constants.cs
@@ -21,6 +21,7 @@ namespace Piranha.Analyzers
         {
             internal const string PiranhaAttributeBuilderPageTypeAttribute = "Piranha.AttributeBuilder.PageTypeAttribute";
             internal const string PiranhaAttributeBuilderPostTypeAttribute = "Piranha.AttributeBuilder.PostTypeAttribute";
+            internal const string PiranhaAttributeBuilderSiteTypeAttribute = "Piranha.AttributeBuilder.SiteTypeAttribute";
 
             internal const string PiranhaExtendFieldAttribute = "Piranha.Extend.FieldAttribute";
             internal const string PiranhaExtendRegionAttribute = "Piranha.Extend.RegionAttribute";
@@ -39,6 +40,7 @@ namespace Piranha.Analyzers
 
             internal const string PiranhaModelsPage = "Piranha.Models.Page";
             internal const string PiranhaModelsPost = "Piranha.Models.Post";
+            internal const string PiranhaModelsSiteContent = "Piranha.Models.SiteContent";
         }
     }
 }

--- a/src/Piranha.Analyzers/PageTypeAttributeOnlyForClassesInheritingPageAnalyzer.cs
+++ b/src/Piranha.Analyzers/PageTypeAttributeOnlyForClassesInheritingPageAnalyzer.cs
@@ -1,0 +1,136 @@
+﻿/*
+ * Copyright (c) 2020 Mikael Lindemann
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * https://github.com/piranhacms/piranha.core.analyzers
+ *
+ */
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Piranha.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class PageTypeAttributeOnlyForClassesInheritingPageAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "PA0004";
+        private const string Category = "Usage";
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.PageTypeAttributeOnlyForClassesInheritingPageAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.PageTypeAttributeOnlyForClassesInheritingPageAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.PageTypeAttributeOnlyForClassesInheritingPageAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(AnalyzeSyntaxNode, SyntaxKind.Attribute);
+        }
+
+        private static void AnalyzeSyntaxNode(SyntaxNodeAnalysisContext context)
+        {
+            if (!(context.Node is AttributeSyntax attribute))
+            {
+                return;
+            }
+
+            var regionAttributeType = context.Compilation.GetTypeByMetadataName(Constants.Types.PiranhaAttributeBuilderPageTypeAttribute);
+
+            if (regionAttributeType == null)
+            {
+                return;
+            }
+
+            var attributeType = context.SemanticModel.GetTypeInfo(attribute, context.CancellationToken);
+
+            if (!regionAttributeType.Equals(attributeType.ConvertedType, SymbolEqualityComparer.IncludeNullability))
+            {
+                return;
+            }
+
+            if (!(attribute.Parent is AttributeListSyntax attributeList))
+            {
+                return;
+            }
+
+            if (!(attributeList.Parent is ClassDeclarationSyntax @class))
+            {
+                return;
+            }
+
+            var pageType = context.Compilation.GetTypeByMetadataName($"{Constants.Types.PiranhaModelsPage}`1");
+
+            if (pageType == null)
+            {
+                return;
+            }
+
+            var unboundPageType = pageType.ConstructUnboundGenericType();
+
+            if (@class.BaseList != null && @class.BaseList.Types.Count != 0)
+            {
+                foreach (var type in @class.BaseList.Types)
+                {
+                    if (!(context.SemanticModel.GetTypeInfo(type.Type, context.CancellationToken).ConvertedType is INamedTypeSymbol convertedType))
+                    {
+                        continue;
+                    }
+
+                    if (InheritsPage(convertedType, pageType, unboundPageType))
+                    {
+                        return;
+                    }
+                }
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, @class.GetLocation(), @class.Identifier.ValueText));
+        }
+
+        private static bool InheritsPage(INamedTypeSymbol type, INamedTypeSymbol pageType, INamedTypeSymbol unboundPageType)
+        {
+            if (type == null)
+            {
+                return false;
+            }
+
+            if (type.SpecialType == SpecialType.System_Object)
+            {
+                return false;
+            }
+
+            if (!type.IsGenericType || !unboundPageType.Equals(type.ConstructUnboundGenericType(), SymbolEqualityComparer.IncludeNullability))
+            {
+                var baseType = type.BaseType;
+                if (baseType != null && InheritsPage(baseType, pageType, unboundPageType))
+                {
+                    return true;
+                }
+            }
+
+            if (type.TypeArguments.Length != 1)
+            {
+                return false;
+            }
+
+            var constructedType = pageType.Construct(type.TypeArguments.First());
+
+            if (constructedType.Equals(type, SymbolEqualityComparer.IncludeNullability))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Piranha.Analyzers/Piranha.Analyzers.csproj
+++ b/src/Piranha.Analyzers/Piranha.Analyzers.csproj
@@ -4,15 +4,15 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <Version>8.2.0</Version>
+    <Version>8.3.0</Version>
     <Company>Piranha CMS</Company>
     <AssemblyTitle>Piranha.Analyzers</AssemblyTitle>
     <NuspecFile>../../nuspec/Piranha.Analyzers.nuspec</NuspecFile>
     <NuspecProperties>version=$(Version);configuration=$(Configuration)</NuspecProperties>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Resources.resx" />

--- a/src/Piranha.Analyzers/Piranha.Analyzers.csproj
+++ b/src/Piranha.Analyzers/Piranha.Analyzers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
-    <PackageReference Include="Piranha" Version="8.2.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Resources.resx" />

--- a/src/Piranha.Analyzers/Piranha.Analyzers.csproj
+++ b/src/Piranha.Analyzers/Piranha.Analyzers.csproj
@@ -4,7 +4,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <Version>8.3.0</Version>
+    <Version>8.4.0</Version>
     <Company>Piranha CMS</Company>
     <AssemblyTitle>Piranha.Analyzers</AssemblyTitle>
     <NuspecFile>../../nuspec/Piranha.Analyzers.nuspec</NuspecFile>

--- a/src/Piranha.Analyzers/PostTypeAttributeOnlyForClassesInheritingPostAnalyzer.cs
+++ b/src/Piranha.Analyzers/PostTypeAttributeOnlyForClassesInheritingPostAnalyzer.cs
@@ -1,12 +1,20 @@
-﻿using Microsoft.CodeAnalysis;
+﻿/*
+ * Copyright (c) 2020 Mikael Lindemann
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * https://github.com/piranhacms/piranha.core.analyzers
+ *
+ */
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 
 namespace Piranha.Analyzers
 {

--- a/src/Piranha.Analyzers/PostTypeAttributeOnlyForClassesInheritingPostAnalyzer.cs
+++ b/src/Piranha.Analyzers/PostTypeAttributeOnlyForClassesInheritingPostAnalyzer.cs
@@ -1,0 +1,128 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+
+namespace Piranha.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class PostTypeAttributeOnlyForClassesInheritingPostAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "PA0003";
+        private const string Category = "Usage";
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.PostTypeAttributeOnlyForClassesInheritingPostAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.PostTypeAttributeOnlyForClassesInheritingPostAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.PostTypeAttributeOnlyForClassesInheritingPostAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(AnalyzeSyntaxNode, SyntaxKind.Attribute);
+        }
+
+        private static void AnalyzeSyntaxNode(SyntaxNodeAnalysisContext context)
+        {
+            if (!(context.Node is AttributeSyntax attribute))
+            {
+                return;
+            }
+
+            var regionAttributeType = context.Compilation.GetTypeByMetadataName(Constants.Types.PiranhaAttributeBuilderPostTypeAttribute);
+
+            if (regionAttributeType == null)
+            {
+                return;
+            }
+
+            var attributeType = context.SemanticModel.GetTypeInfo(attribute, context.CancellationToken);
+
+            if (!regionAttributeType.Equals(attributeType.ConvertedType, SymbolEqualityComparer.IncludeNullability))
+            {
+                return;
+            }
+
+            if (!(attribute.Parent is AttributeListSyntax attributeList))
+            {
+                return;
+            }
+
+            if (!(attributeList.Parent is ClassDeclarationSyntax @class))
+            {
+                return;
+            }
+
+            var postType = context.Compilation.GetTypeByMetadataName($"{Constants.Types.PiranhaModelsPost}`1");
+
+            if (postType == null)
+            {
+                return;
+            }
+
+            if (@class.BaseList != null && @class.BaseList.Types.Count != 0)
+            {
+                foreach (var type in @class.BaseList.Types)
+                {
+                    if (!(context.SemanticModel.GetTypeInfo(type.Type, context.CancellationToken).ConvertedType is INamedTypeSymbol convertedType))
+                    {
+                        continue;
+                    }
+
+                    if (InheritsPost(context, convertedType))
+                    {
+                        return;
+                    }
+                }
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, @class.GetLocation(), @class.Identifier.ValueText));
+        }
+
+        private static bool InheritsPost(SyntaxNodeAnalysisContext context, INamedTypeSymbol type)
+        {
+            var postType = context.Compilation.GetTypeByMetadataName($"{Constants.Types.PiranhaModelsPost}`1");
+
+            if (postType == null)
+            {
+                throw new InvalidOperationException("Post type is unavailable. Do you have a missing assembly reference?");
+            }
+
+            if (type == null)
+            {
+                return false;
+            }
+
+            if (type.MetadataName != Constants.Types.PiranhaModelsPost)
+            {
+                var baseType = type.BaseType;
+                if (baseType != null && InheritsPost(context, baseType))
+                {
+                    return true;
+                }
+            }
+
+            if (type.TypeArguments.Length != 1)
+            {
+                return false;
+            }
+
+            var constructedType = postType.Construct(type.TypeArguments.First());
+
+            if (constructedType.Equals(type, SymbolEqualityComparer.IncludeNullability))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Piranha.Analyzers/Resources.Designer.cs
+++ b/src/Piranha.Analyzers/Resources.Designer.cs
@@ -167,5 +167,32 @@ namespace Piranha.Analyzers {
                 return ResourceManager.GetString("PostTypeAttributeOnlyForClassesInheritingPostAnalyzerTitle", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [SiteType] should only be applied to classes inheriting SiteContent..
+        /// </summary>
+        internal static string SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerDescription {
+            get {
+                return ResourceManager.GetString("SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} does not extend SiteContent, but is marked with [SiteType].
+        /// </summary>
+        internal static string SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [SiteType] should only be applied to classes inheriting SiteContent..
+        /// </summary>
+        internal static string SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerTitle", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Piranha.Analyzers/Resources.Designer.cs
+++ b/src/Piranha.Analyzers/Resources.Designer.cs
@@ -113,5 +113,32 @@ namespace Piranha.Analyzers {
                 return ResourceManager.GetString("NonSingleFieldRegionAnalyzerTitle", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [PostType] should only be applied to classes inheriting Post..
+        /// </summary>
+        internal static string PostTypeAttributeOnlyForClassesInheritingPostAnalyzerDescription {
+            get {
+                return ResourceManager.GetString("PostTypeAttributeOnlyForClassesInheritingPostAnalyzerDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} does not extend Post, but is marked with [PostType].
+        /// </summary>
+        internal static string PostTypeAttributeOnlyForClassesInheritingPostAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("PostTypeAttributeOnlyForClassesInheritingPostAnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [PostType] should only be applied to classes inheriting Post..
+        /// </summary>
+        internal static string PostTypeAttributeOnlyForClassesInheritingPostAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("PostTypeAttributeOnlyForClassesInheritingPostAnalyzerTitle", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Piranha.Analyzers/Resources.Designer.cs
+++ b/src/Piranha.Analyzers/Resources.Designer.cs
@@ -115,6 +115,33 @@ namespace Piranha.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to [PageType] should only be applied to classes inheriting Page..
+        /// </summary>
+        internal static string PageTypeAttributeOnlyForClassesInheritingPageAnalyzerDescription {
+            get {
+                return ResourceManager.GetString("PageTypeAttributeOnlyForClassesInheritingPageAnalyzerDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} does not extend Page, but is marked with [PageType].
+        /// </summary>
+        internal static string PageTypeAttributeOnlyForClassesInheritingPageAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("PageTypeAttributeOnlyForClassesInheritingPageAnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [PageType] should only be applied to classes inheriting Page..
+        /// </summary>
+        internal static string PageTypeAttributeOnlyForClassesInheritingPageAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("PageTypeAttributeOnlyForClassesInheritingPageAnalyzerTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [PostType] should only be applied to classes inheriting Post..
         /// </summary>
         internal static string PostTypeAttributeOnlyForClassesInheritingPostAnalyzerDescription {

--- a/src/Piranha.Analyzers/Resources.resx
+++ b/src/Piranha.Analyzers/Resources.resx
@@ -150,4 +150,13 @@
   <data name="PostTypeAttributeOnlyForClassesInheritingPostAnalyzerTitle" xml:space="preserve">
     <value>[PostType] should only be applied to classes inheriting Post.</value>
   </data>
+  <data name="PageTypeAttributeOnlyForClassesInheritingPageAnalyzerDescription" xml:space="preserve">
+    <value>[PageType] should only be applied to classes inheriting Page.</value>
+  </data>
+  <data name="PageTypeAttributeOnlyForClassesInheritingPageAnalyzerMessageFormat" xml:space="preserve">
+    <value>{0} does not extend Page, but is marked with [PageType]</value>
+  </data>
+  <data name="PageTypeAttributeOnlyForClassesInheritingPageAnalyzerTitle" xml:space="preserve">
+    <value>[PageType] should only be applied to classes inheriting Page.</value>
+  </data>
 </root>

--- a/src/Piranha.Analyzers/Resources.resx
+++ b/src/Piranha.Analyzers/Resources.resx
@@ -159,4 +159,13 @@
   <data name="PageTypeAttributeOnlyForClassesInheritingPageAnalyzerTitle" xml:space="preserve">
     <value>[PageType] should only be applied to classes inheriting Page.</value>
   </data>
+  <data name="SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerDescription" xml:space="preserve">
+    <value>[SiteType] should only be applied to classes inheriting SiteContent.</value>
+  </data>
+  <data name="SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerMessageFormat" xml:space="preserve">
+    <value>{0} does not extend SiteContent, but is marked with [SiteType]</value>
+  </data>
+  <data name="SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerTitle" xml:space="preserve">
+    <value>[SiteType] should only be applied to classes inheriting SiteContent.</value>
+  </data>
 </root>

--- a/src/Piranha.Analyzers/Resources.resx
+++ b/src/Piranha.Analyzers/Resources.resx
@@ -141,4 +141,13 @@
     <value>Complex regions with only one field is not supported.</value>
     <comment>The title of the diagnostic.</comment>
   </data>
+  <data name="PostTypeAttributeOnlyForClassesInheritingPostAnalyzerDescription" xml:space="preserve">
+    <value>[PostType] should only be applied to classes inheriting Post.</value>
+  </data>
+  <data name="PostTypeAttributeOnlyForClassesInheritingPostAnalyzerMessageFormat" xml:space="preserve">
+    <value>{0} does not extend Post, but is marked with [PostType]</value>
+  </data>
+  <data name="PostTypeAttributeOnlyForClassesInheritingPostAnalyzerTitle" xml:space="preserve">
+    <value>[PostType] should only be applied to classes inheriting Post.</value>
+  </data>
 </root>

--- a/src/Piranha.Analyzers/Resources.resx
+++ b/src/Piranha.Analyzers/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NonSingleFieldRegionAnalyzerDescription" xml:space="preserve">
-    <value>Usage of field type as a single field region might not be supported</value>
+    <value>Usage of field type as a single field region might not be supported.</value>
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
   <data name="NonSingleFieldRegionAnalyzerMessageFormat" xml:space="preserve">
@@ -138,7 +138,7 @@
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
   <data name="InvalidSingleFieldComplexRegionAnalyzerTitle" xml:space="preserve">
-    <value>Complex regions with only one field is not supported.</value>
+    <value>Complex regions with only one field is not supported</value>
     <comment>The title of the diagnostic.</comment>
   </data>
   <data name="PostTypeAttributeOnlyForClassesInheritingPostAnalyzerDescription" xml:space="preserve">
@@ -148,7 +148,7 @@
     <value>{0} does not extend Post, but is marked with [PostType]</value>
   </data>
   <data name="PostTypeAttributeOnlyForClassesInheritingPostAnalyzerTitle" xml:space="preserve">
-    <value>[PostType] should only be applied to classes inheriting Post.</value>
+    <value>[PostType] should only be applied to classes inheriting Post</value>
   </data>
   <data name="PageTypeAttributeOnlyForClassesInheritingPageAnalyzerDescription" xml:space="preserve">
     <value>[PageType] should only be applied to classes inheriting Page.</value>
@@ -157,7 +157,7 @@
     <value>{0} does not extend Page, but is marked with [PageType]</value>
   </data>
   <data name="PageTypeAttributeOnlyForClassesInheritingPageAnalyzerTitle" xml:space="preserve">
-    <value>[PageType] should only be applied to classes inheriting Page.</value>
+    <value>[PageType] should only be applied to classes inheriting Page</value>
   </data>
   <data name="SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerDescription" xml:space="preserve">
     <value>[SiteType] should only be applied to classes inheriting SiteContent.</value>
@@ -166,6 +166,6 @@
     <value>{0} does not extend SiteContent, but is marked with [SiteType]</value>
   </data>
   <data name="SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerTitle" xml:space="preserve">
-    <value>[SiteType] should only be applied to classes inheriting SiteContent.</value>
+    <value>[SiteType] should only be applied to classes inheriting SiteContent</value>
   </data>
 </root>

--- a/src/Piranha.Analyzers/SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzer.cs
+++ b/src/Piranha.Analyzers/SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzer.cs
@@ -1,0 +1,136 @@
+﻿/*
+ * Copyright (c) 2020 Mikael Lindemann
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * https://github.com/piranhacms/piranha.core.analyzers
+ *
+ */
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Piranha.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SiteTypeAttributeOnlyForClassesInheritingSiteContentAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "PA0005";
+        private const string Category = "Usage";
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.SiteTypeAttributeOnlyForClassesInheritingSiteAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(AnalyzeSyntaxNode, SyntaxKind.Attribute);
+        }
+
+        private static void AnalyzeSyntaxNode(SyntaxNodeAnalysisContext context)
+        {
+            if (!(context.Node is AttributeSyntax attribute))
+            {
+                return;
+            }
+
+            var regionAttributeType = context.Compilation.GetTypeByMetadataName(Constants.Types.PiranhaAttributeBuilderSiteTypeAttribute);
+
+            if (regionAttributeType == null)
+            {
+                return;
+            }
+
+            var attributeType = context.SemanticModel.GetTypeInfo(attribute, context.CancellationToken);
+
+            if (!regionAttributeType.Equals(attributeType.ConvertedType, SymbolEqualityComparer.IncludeNullability))
+            {
+                return;
+            }
+
+            if (!(attribute.Parent is AttributeListSyntax attributeList))
+            {
+                return;
+            }
+
+            if (!(attributeList.Parent is ClassDeclarationSyntax @class))
+            {
+                return;
+            }
+
+            var siteType = context.Compilation.GetTypeByMetadataName($"{Constants.Types.PiranhaModelsSiteContent}`1");
+
+            if (siteType == null)
+            {
+                return;
+            }
+
+            var unboundSiteType = siteType.ConstructUnboundGenericType();
+
+            if (@class.BaseList != null && @class.BaseList.Types.Count != 0)
+            {
+                foreach (var type in @class.BaseList.Types)
+                {
+                    if (!(context.SemanticModel.GetTypeInfo(type.Type, context.CancellationToken).ConvertedType is INamedTypeSymbol convertedType))
+                    {
+                        continue;
+                    }
+
+                    if (InheritsSite(convertedType, siteType, unboundSiteType))
+                    {
+                        return;
+                    }
+                }
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, @class.GetLocation(), @class.Identifier.ValueText));
+        }
+
+        private static bool InheritsSite(INamedTypeSymbol type, INamedTypeSymbol siteType, INamedTypeSymbol unboundSiteType)
+        {
+            if (type == null)
+            {
+                return false;
+            }
+
+            if (type.SpecialType == SpecialType.System_Object)
+            {
+                return false;
+            }
+
+            if (!type.IsGenericType || !unboundSiteType.Equals(type.ConstructUnboundGenericType(), SymbolEqualityComparer.IncludeNullability))
+            {
+                var baseType = type.BaseType;
+                if (baseType != null && InheritsSite(baseType, siteType, unboundSiteType))
+                {
+                    return true;
+                }
+            }
+
+            if (type.TypeArguments.Length != 1)
+            {
+                return false;
+            }
+
+            var constructedType = siteType.Construct(type.TypeArguments.First());
+
+            if (constructedType.Equals(type, SymbolEqualityComparer.IncludeNullability))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/test/Piranha.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/test/Piranha.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -33,7 +33,8 @@ namespace TestHelper
         private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
         private static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
         private static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
-        private static readonly MetadataReference PiranhaReference = MetadataReference.CreateFromFile(typeof(Piranha.Models.Content).Assembly.Location);
+        private static readonly MetadataReference PiranhaReference = MetadataReference.CreateFromFile(typeof(Piranha.Models.ContentBase).Assembly.Location);
+        private static readonly MetadataReference PiranhaAttributeBuilderReference = MetadataReference.CreateFromFile(typeof(Piranha.AttributeBuilder.PostTypeAttribute).Assembly.Location);
 
         internal static string DefaultFilePathPrefix = "Test";
         internal static string CSharpDefaultFileExt = "cs";
@@ -170,7 +171,8 @@ namespace TestHelper
                 .AddMetadataReference(projectId, SystemCoreReference)
                 .AddMetadataReference(projectId, CSharpSymbolsReference)
                 .AddMetadataReference(projectId, CodeAnalysisReference)
-                .AddMetadataReference(projectId, PiranhaReference);
+                .AddMetadataReference(projectId, PiranhaReference)
+                .AddMetadataReference(projectId, PiranhaAttributeBuilderReference);
 
             int count = 0;
             foreach (var source in sources)

--- a/test/Piranha.Analyzers.Test/MoveToExistingComplexRegionCodeFixProviderTests.cs
+++ b/test/Piranha.Analyzers.Test/MoveToExistingComplexRegionCodeFixProviderTests.cs
@@ -1,9 +1,17 @@
-﻿using Microsoft.CodeAnalysis;
+﻿/*
+ * Copyright (c) 2020 Mikael Lindemann
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * https://github.com/piranhacms/piranha.core.analyzers
+ *
+ */
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using TestHelper;
 using Xunit;

--- a/test/Piranha.Analyzers.Test/PageTypeAttributeOnlyForClassesInheritingPageAnalyzerTests.cs
+++ b/test/Piranha.Analyzers.Test/PageTypeAttributeOnlyForClassesInheritingPageAnalyzerTests.cs
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2020 Mikael Lindemann
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * https://github.com/piranhacms/piranha.core.analyzers
+ *
+ */
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using TestHelper;
+using Xunit;
+
+namespace Piranha.Analyzers.Test
+{
+    public class PageTypeAttributeOnlyForClassesInheritingPageAnalyzerTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task ClassWithPageTypeAttributeDirectlyInheritingPage()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [PageType]",
+                "    class TypeName : Page<TypeName>",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+
+            await VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public async Task ClassWithPageTypeAttributeIndirectlyInheritingPage()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [PageType]",
+                "    class TypeName : MyPage<TypeName>",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    class MyPage<T> : Page<T>",
+                "    {}",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+
+            await VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public async Task ClassWithPageTypeAttributeIndirectlyInheritingPage2()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [PageType]",
+                "    class TypeName : MyPage2",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    abstract class MyPage : Page<TypeName>",
+                "    {}",
+                "    abstract class MyPage2 : MyPage",
+                "    {}",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+
+            await VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public async Task ClassWithPageTypeAttributeWithoutPageAsBaseClass()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [PageType]",
+                "    class TypeName",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+            var expected = new DiagnosticResult
+            {
+                Id = "PA0004",
+                Message = "TypeName does not extend Page, but is marked with [PageType]",
+                Severity = DiagnosticSeverity.Error,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 8, 5)
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+
+
+        [Fact]
+        public async Task ClassWithPageTypeAttributeWithCustomPageAsBaseClass()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [PageType]",
+                "    class TypeName : Page<TypeName>",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    class Page<T> where T : Page<T>",
+                "    {}",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+            var expected = new DiagnosticResult
+            {
+                Id = "PA0004",
+                Message = "TypeName does not extend Page, but is marked with [PageType]",
+                Severity = DiagnosticSeverity.Error,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 8, 5)
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return null;
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new PageTypeAttributeOnlyForClassesInheritingPageAnalyzer();
+        }
+    }
+}

--- a/test/Piranha.Analyzers.Test/Piranha.Analyzers.Test.csproj
+++ b/test/Piranha.Analyzers.Test/Piranha.Analyzers.Test.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Piranha.AttributeBuilder" Version="8.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Piranha.Analyzers.Test/Piranha.Analyzers.Test.csproj
+++ b/test/Piranha.Analyzers.Test/Piranha.Analyzers.Test.csproj
@@ -4,16 +4,16 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Piranha.AttributeBuilder" Version="8.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="Piranha.AttributeBuilder" Version="8.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Piranha" Version="8.2.0" />
+    <PackageReference Include="Piranha" Version="8.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Piranha.Analyzers\Piranha.Analyzers.csproj" />

--- a/test/Piranha.Analyzers.Test/Piranha.Analyzers.Test.csproj
+++ b/test/Piranha.Analyzers.Test/Piranha.Analyzers.Test.csproj
@@ -6,14 +6,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-    <PackageReference Include="Piranha.AttributeBuilder" Version="8.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Piranha.AttributeBuilder" Version="8.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Piranha" Version="8.3.0" />
+    <PackageReference Include="Piranha" Version="8.4.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Piranha.Analyzers\Piranha.Analyzers.csproj" />

--- a/test/Piranha.Analyzers.Test/PostTypeAttributeOnlyForClassesInheritingPostAnalyzerTests.cs
+++ b/test/Piranha.Analyzers.Test/PostTypeAttributeOnlyForClassesInheritingPostAnalyzerTests.cs
@@ -1,0 +1,210 @@
+
+/*
+ * Copyright (c) 2020 Mikael Lindemann
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * https://github.com/piranhacms/piranha.core.analyzers
+ *
+ */
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using TestHelper;
+using Xunit;
+
+namespace Piranha.Analyzers.Test
+{
+    public class PostTypeAttributeOnlyForClassesInheritingPostAnalyzerTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task ClassWithPostTypeAttributeDirectlyInheritingPost()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [PostType]",
+                "    class TypeName : Post<TypeName>",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+
+            await VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public async Task ClassWithPostTypeAttributeIndirectlyInheritingPost()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [PostType]",
+                "    class TypeName : MyPost<TypeName>",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    class MyPost<T> : Post<T>",
+                "    {}",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+
+            await VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public async Task ClassWithPostTypeAttributeIndirectlyInheritingPost2()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [PostType]",
+                "    class TypeName : MyPost2",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    abstract class MyPost : Post<TypeName>",
+                "    {}",
+                "    abstract class MyPost2 : MyPost",
+                "    {}",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+
+            await VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public async Task ClassWithPostTypeAttributeWithoutPostAsBaseClass()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [PostType]",
+                "    class TypeName",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+            var expected = new DiagnosticResult
+            {
+                Id = "PA0003",
+                Message = "TypeName does not extend Post, but is marked with [PostType]",
+                Severity = DiagnosticSeverity.Error,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 8, 5)
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+
+
+        [Fact]
+        public async Task ClassWithPostTypeAttributeWithCustomPostAsBaseClass()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [PostType]",
+                "    class TypeName : Post<TypeName>",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    class Post<T> where T : Post<T>",
+                "    {}",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+            var expected = new DiagnosticResult
+            {
+                Id = "PA0003",
+                Message = "TypeName does not extend Post, but is marked with [PostType]",
+                Severity = DiagnosticSeverity.Error,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 8, 5)
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return null;
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new PostTypeAttributeOnlyForClassesInheritingPostAnalyzer();
+        }
+    }
+}

--- a/test/Piranha.Analyzers.Test/PostTypeAttributeOnlyForClassesInheritingPostAnalyzerTests.cs
+++ b/test/Piranha.Analyzers.Test/PostTypeAttributeOnlyForClassesInheritingPostAnalyzerTests.cs
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2020 Mikael Lindemann
  *

--- a/test/Piranha.Analyzers.Test/SiteTypeAttributeOnlyForClassesInheritingSiteContentAnalyzerTests.cs
+++ b/test/Piranha.Analyzers.Test/SiteTypeAttributeOnlyForClassesInheritingSiteContentAnalyzerTests.cs
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2020 Mikael Lindemann
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * https://github.com/piranhacms/piranha.core.analyzers
+ *
+ */
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using TestHelper;
+using Xunit;
+
+namespace Piranha.Analyzers.Test
+{
+    public class SiteTypeAttributeOnlyForClassesInheritingSiteContentAnalyzerTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task ClassWithSiteTypeAttributeDirectlyInheritingSiteContent()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [SiteType]",
+                "    class TypeName : SiteContent<TypeName>",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+
+            await VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public async Task ClassWithSiteTypeAttributeIndirectlyInheritingSiteContent()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [SiteType]",
+                "    class TypeName : MySiteContent<TypeName>",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    class MySiteContent<T> : SiteContent<T>",
+                "    {}",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+
+            await VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public async Task ClassWithSiteTypeAttributeIndirectlyInheritingSiteContent2()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [SiteType]",
+                "    class TypeName : MySiteContent2",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    abstract class MySiteContent : SiteContent<TypeName>",
+                "    {}",
+                "    abstract class MySiteContent2 : MySiteContent",
+                "    {}",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+
+            await VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public async Task ClassWithSiteTypeAttributeWithoutSiteContentAsBaseClass()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [SiteType]",
+                "    class TypeName",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+            var expected = new DiagnosticResult
+            {
+                Id = "PA0005",
+                Message = "TypeName does not extend SiteContent, but is marked with [SiteType]",
+                Severity = DiagnosticSeverity.Error,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 8, 5)
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+
+
+        [Fact]
+        public async Task ClassWithSiteTypeAttributeWithCustomSiteContentAsBaseClass()
+        {
+            var test = string.Join(Environment.NewLine,
+                "using Piranha.AttributeBuilder;",
+                "using Piranha.Extend;",
+                "using Piranha.Extend.Fields;",
+                "using Piranha.Models;",
+                "",
+                "namespace ConsoleApplication1",
+                "{",
+                "    [SiteType]",
+                "    class TypeName : SiteContent<TypeName>",
+                "    {",
+                "        [Region]",
+                "        public HeroRegion Hero { get; set; }",
+                "    }",
+                "    class SiteContent<T> where T : SiteContent<T>",
+                "    {}",
+                "    class HeroRegion",
+                "    {",
+                "        [Field]",
+                "        public AudioField Audio { get; set; }",
+                "        [Field]",
+                "        public AudioField Audio2 { get; set; }",
+                "    }",
+                "}");
+            var expected = new DiagnosticResult
+            {
+                Id = "PA0005",
+                Message = "TypeName does not extend SiteContent, but is marked with [SiteType]",
+                Severity = DiagnosticSeverity.Error,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 8, 5)
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return null;
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new SiteTypeAttributeOnlyForClassesInheritingSiteContentAnalyzer();
+        }
+    }
+}


### PR DESCRIPTION
* Upgraded libraries to test against Piranha 8.4.0
* Added PA0003, PA0004, PA0005 to catch types with applied page/post/site type attributes that does not extend the proper base classes.